### PR TITLE
#410 - Modify template to use callbacks

### DIFF
--- a/generators/app/templates/plugin/www/client.js
+++ b/generators/app/templates/plugin/www/client.js
@@ -22,14 +22,13 @@ var _self = {},
 	// They make WebWorks function calls to the methods
 	// in the index.js of the Extension
 
-	// Simple Synchronous test function to get a string
-
-	function invokeCallback(callback, args) {
-    if (callback && typeof callback === "function") {
-        callback(args);
-    }
+function invokeCallBack(callback, args) {
+	if (callback && typeof callback === "function") {
+		callback(args);
+	}
 }
 
+	// Simple Synchronous test function to get a string
 
 	_self.<%= projectCamel %>Test = function (onSuccess, onFail) {
 		exec(function (result) {

--- a/generators/app/templates/plugin/www/client.js
+++ b/generators/app/templates/plugin/www/client.js
@@ -22,7 +22,7 @@ var _self = {},
 	// They make WebWorks function calls to the methods
 	// in the index.js of the Extension
 
-function invokeCallBack(callback, args) {
+function invokeCallback(callback, args) {
 	if (callback && typeof callback === "function") {
 		callback(args);
 	}
@@ -96,15 +96,13 @@ function invokeCallBack(callback, args) {
 	};
 
 	_self.<%= projectCamel %>StopThread = function (callback) {
-		var result,
 			success = function (data, response) {
-				result = data;
+				callback(data);
 			},
 			fail = function (data, response) {
 				console.log("Error: " + data);
 			};
 		exec(success, fail, _ID, "<%= projectCamel %>StopThread", null);
-		return result;
 	};
 
 module.exports = _self;

--- a/generators/app/templates/plugin/www/client.js
+++ b/generators/app/templates/plugin/www/client.js
@@ -23,27 +23,28 @@ var _self = {},
 	// in the index.js of the Extension
 
 	// Simple Synchronous test function to get a string
-	_self.<%= projectCamel %>Test = function () {
-		var result,
-			success = function (data, response) {
-				result = data;
-			},
-			fail = function (data, response) {
-				console.log("Error: " + data);
-			};
-		exec(success, fail, _ID, "<%= projectCamel %>Test", null);
-		return result;
+
+	function invokeCallback(callback, args) {
+    if (callback && typeof callback === "function") {
+        callback(args);
+    }
+}
+
+
+	_self.<%= projectCamel %>Test = function (onSuccess, onFail) {
+		exec(function (result) {
+			invokeCallback(onSuccess, result);
+		}, function(error) {
+			invokeCallback(onFail, error);
+		}, _ID, "<%= projectCamel %>Test", null);
 	};
-	_self.<%= projectCamel %>TestInput = function (input) {
-		var result,
-			success = function (data, response) {
-				result = data;
-			},
-			fail = function (data, response) {
-				console.log("Error: " + data);
-			};
-		exec(success, fail, _ID, "<%= projectCamel %>TestInput", { input: input });
-		return result;
+
+	_self.<%= projectCamel %>TestInput = function (input, onSuccess, onFail) {
+		exec(function (result) {
+			invokeCallback(onSuccess, result);
+		}, function(error) {
+			invokeCallback(onFail, error);
+		}, _ID, "<%= projectCamel %>TestInput", { input: input });
 	};
 
 	// Asynchronous with sending and returning a JSON object


### PR DESCRIPTION
#410

Testing workflow:
Generate a new plugin using the new template, and install it on a sample application.
Run the web application and in the web console, define a simple call back function that logs the data.

Called each of the functions that were changed to use callbacks (Test, TestInput, StopThread) and the behaviour worked as expected. Return data was logged, threads were started/stopped appropriately. 
